### PR TITLE
Allow configuring path to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Allows you to get the npm version of the package in your Github Actions workflow
 
 ## Usage
 
+### Inputs
+
+- `path`: The directory where package.json can be found (defaults to root of repo)
+
 ### Outputs
 
 - `version`: The version of current NPM package
@@ -26,6 +30,31 @@ jobs:
       - name: Extract version
         id: extract_version
         uses: Saionaro/extract-package-version@v1.0.6
+      # From now you can access version
+      - name: Print version
+        run: echo ${{ steps.extract_version.outputs.version }}
+```
+
+### Example workflow - get NPM version of subdirectory
+
+```yaml
+on: push
+
+name: Create Build
+
+jobs:
+  build:
+    name: Create Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Extract version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+        with:
+          path: mysubdir
       # From now you can access version
       - name: Print version
         run: echo ${{ steps.extract_version.outputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: Extract Package Version
 description: Extract Package Version for npm packages.
 author: "Saionaro"
+inputs:
+  path:
+    description: 'The directory where package.json can be found (defaults to root of repo)'
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -60,7 +60,10 @@ const workspace = process.env.GITHUB_WORKSPACE;
 
 async function run() {
   try {
-    const packagePath = path.join(workspace, "package.json");
+    let dir = core.getInput("path") || workspace;
+    dir = path.resolve(dir);
+
+    const packagePath = path.join(dir, "package.json");
     const pkg = require(packagePath);
     const version = pkg.version.toString();
 

--- a/src/extract-version.js
+++ b/src/extract-version.js
@@ -5,7 +5,10 @@ const workspace = process.env.GITHUB_WORKSPACE;
 
 async function run() {
   try {
-    const packagePath = path.join(workspace, "package.json");
+    let dir = core.getInput("path") || workspace;
+    dir = path.resolve(dir);
+
+    const packagePath = path.join(dir, "package.json");
     const pkg = require(packagePath);
     const version = pkg.version.toString();
 


### PR DESCRIPTION
I have a monorepo and want to grab the version of the `package.json` from a subdirectory. This adds the option to specify the directory to look for `package.json`. It defaults to the root of the repo still.